### PR TITLE
Implementation of the post methods to join (public and private) events

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/EventController.java
@@ -3,6 +3,8 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Event;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventJoinByCodePostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.EventJoinByIdPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.EventPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.service.EventService;
@@ -37,6 +39,28 @@ public class EventController {
         Event eventData = DTOMapper.INSTANCE.convertEventPostDTOtoEntity(eventPostDTO);
         Event newEvent = eventService.createEvent(eventData, token);
         return DTOMapper.INSTANCE.convertEntityToEventGetDTO(newEvent);
+    }
+
+    // Join event by eventId (meant for joins through event search)
+    @PostMapping("/{eventId}/participants")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseBody
+    public EventGetDTO joinEventById(@RequestHeader("Authorization") String authHeader, @PathVariable Long eventId, @RequestBody EventJoinByIdPostDTO eventJoinByIdPostDTO) {
+        String token = authHeader.replace("Bearer ", "");
+        userService.validateToken(token);
+        Event event = eventService.joinEventById(eventId, eventJoinByIdPostDTO.getUserId());
+        return DTOMapper.INSTANCE.convertEntityToEventGetDTO(event);
+    }
+
+    // Join event by inviteCode (meant for joins through invitations)
+    @PostMapping("/participants")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseBody
+    public EventGetDTO joinEventBynviteCode(@RequestHeader("Authorization") String authHeader, @RequestBody EventJoinByCodePostDTO eventJoinByCodePostDTO) {
+        String token = authHeader.replace("Bearer ", "");
+        userService.validateToken(token);
+        Event event = eventService.joinEventByInviteCode(eventJoinByCodePostDTO.getInviteCode(), eventJoinByCodePostDTO.getUserId());
+        return DTOMapper.INSTANCE.convertEntityToEventGetDTO(event);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventJoinByCodePostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventJoinByCodePostDTO.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class EventJoinByCodePostDTO {
+    private String inviteCode;
+    private Long userId;
+
+    public String getInviteCode() {
+        return inviteCode;
+    }
+
+    public void setInviteCode(String inviteCode) {
+        this.inviteCode = inviteCode;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventJoinByIdPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/EventJoinByIdPostDTO.java
@@ -1,0 +1,13 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class EventJoinByIdPostDTO {
+    private Long userId;
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/EventService.java
@@ -92,6 +92,38 @@ public class EventService {
         .toList();
     }
 
+    public Event joinEventById(Long eventId, Long userId) {
+        User userFromId = userRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        Event event = eventRepository.findById((long) eventId);
+        if (event == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found");
+        }
+        if (event.getIsPrivate()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot join a private event without an invite code");
+        }
+        if (event.getParticipants().contains(userFromId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "User already joined the event");
+        }
+        event.getParticipants().add(userFromId);
+        return eventRepository.save(event);
+    }
+
+    public Event joinEventByInviteCode(String inviteCode, Long userId) {
+        User userFromId = userRepository.findById(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        
+        Event event = eventRepository.findByInviteCode(inviteCode);
+        if (event == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found");
+        }
+        if (event.getParticipants().contains(userFromId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "User already joined the event");
+        }
+        event.getParticipants().add(userFromId);
+        return eventRepository.save(event);
+    }
 
 
     /// helper functions ///

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/EventControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/EventControllerTest.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.EventRepository;
+
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 
@@ -27,6 +29,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -45,6 +48,9 @@ public class EventControllerTest {
 
 	@MockitoBean
 	private EventService eventService;
+
+	@MockitoBean
+	private EventRepository eventRepository;
 
 	@MockitoBean
 	private UserService userService;
@@ -125,6 +131,90 @@ public class EventControllerTest {
 				.header("Authorization", "Bearer test-token");
 
 		mockMvc.perform(getRequest).andExpect(status().isNotFound());
+	}
+
+	// POST /events/{eventId}/participants
+	@Test
+	public void joinEventById_whenEventPublic_returns201() throws Exception {
+		User user = new User();
+		user.setId(1L);
+		user.setUsername("alice");
+
+		Event event = new Event();
+		event.setId(1L);
+		event.setTitle("Public Event");
+		event.setIsPrivate(false);
+		event.setParticipants(List.of());
+
+		Mockito.doNothing().when(userService).validateToken(Mockito.anyString());
+
+		given(eventService.joinEventById(1L, 1L)).willReturn(event);
+
+		MockHttpServletRequestBuilder postRequest = post("/events/1/participants")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer test-token")
+				.content("{\"userId\": 1}");
+
+		mockMvc.perform(postRequest).andExpect(status().isCreated())
+				.andExpect(jsonPath("$.title", is(event.getTitle())))
+				.andExpect(jsonPath("$.isPrivate", is(event.getIsPrivate())))
+				.andExpect(jsonPath("$.participantCount", is(0)));
+	}
+
+
+	@Test 
+	public void joinEventById_whenEventIsPrivate_returns403() throws Exception {
+		User user = new User();
+		user.setId(1L);
+		user.setUsername("alice");
+
+		Event event = new Event();
+		event.setId(1L);
+		event.setTitle("Private Event");
+		event.setIsPrivate(true);
+		event.setParticipants(List.of());
+
+		Mockito.doNothing().when(userService).validateToken(Mockito.anyString());
+
+		given(eventService.joinEventById(1L, 1L))
+			.willThrow(new ResponseStatusException(
+				HttpStatus.FORBIDDEN,
+				"Cannot join a private event without an invite code"
+			));
+
+		MockHttpServletRequestBuilder postRequest = post("/events/1/participants")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer test-token")
+				.content("{\"userId\": 1}");
+
+		mockMvc.perform(postRequest).andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void joinEventByinviteCode_whenEventIsPrivate_returns201() throws Exception {
+		User user = new User();
+		user.setId(1L);
+		user.setUsername("alice");
+
+		Event event = new Event();
+		event.setId(1L);
+		event.setTitle("Private Event");
+		event.setIsPrivate(true);
+		event.setParticipants(List.of());
+
+		Mockito.doNothing().when(userService).validateToken(Mockito.anyString());
+
+		given(eventService.joinEventByInviteCode("invite-code", 1L)).willReturn(event);
+
+		MockHttpServletRequestBuilder postRequest = post("/events/participants")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer test-token")
+				.content("{\"inviteCode\": \"invite-code\", \"userId\": 1}");
+
+		mockMvc.perform(postRequest).andExpect(status().isCreated())
+				.andExpect(jsonPath("$.title", is(event.getTitle())))
+				.andExpect(jsonPath("$.isPrivate", is(event.getIsPrivate())))
+				.andExpect(jsonPath("$.participantCount", is(0)));
 	}
 
 	/**


### PR DESCRIPTION
The post methods with endpoints /events/{eventId}/participants (meant for public events that can be found on the map) and /events/participants (meant for private events for which inviteCode is needed but can also be used for oublic events through the inviteCode) can now be used to join events. Some tests were also implemented in the EventController to see if the endpoints work.