### PR TITLE
feat: migrate from H2 in-memory to Cloud SQL Postgres

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,17 @@ jobs:
       - name: Build with Gradle
         run: chmod +x gradlew && ./gradlew build -x test --no-daemon
 
+      - name: Inject DB_PASSWORD into app.yaml
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: |
+          python3 -c "
+          import os
+          with open('app.yaml', 'r') as f: c = f.read()
+          c = c.replace('REPLACE_ME_BEFORE_DEPLOY', os.environ['DB_PASSWORD'])
+          with open('app.yaml', 'w') as f: f.write(c)
+          "
+
       - name: Deploy to App Engine
         id: deploy
         uses: google-github-actions/deploy-appengine@v0.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ hs_err_pid*
 # don't track the local.properties -> contains secrets
 local.properties
 
+# local env vars for prod profile testing (Cloud SQL password etc.)
+.env.local
+.env.local.*
+
 .vscode
 .xcode*
 

--- a/app.yaml
+++ b/app.yaml
@@ -8,3 +8,10 @@ automatic_scaling:
   min_instances: 1
   max_instances: 1
   min_idle_instances: 1
+
+beta_settings:
+  cloud_sql_instances: sopra-fs26-group-21-server:europe-west6:sopra-fs26-db
+
+env_variables:
+  SPRING_PROFILES_ACTIVE: prod
+  DB_PASSWORD: "REPLACE_ME_BEFORE_DEPLOY"

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.google.cloud.sql:postgres-socket-factory:1.20.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'   

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Lance Spring Boot en mode prod (Cloud SQL Postgres) en local.
+# Charge DB_PASSWORD depuis .env.local (gitignoré).
+# Prérequis: gcloud auth application-default login (une seule fois).
+
+set -e
+
+if [ ! -f .env.local ]; then
+  echo "❌ .env.local introuvable. Crée-le avec: DB_PASSWORD=<password spring-app>" >&2
+  exit 1
+fi
+
+set -a
+. ./.env.local
+set +a
+
+export SPRING_PROFILES_ACTIVE=prod
+exec ./gradlew bootRun

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Post.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Post.java
@@ -20,7 +20,7 @@ public class Post {
     private String content;
 
     @Lob
-    @Column(columnDefinition = "CLOB")
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
     private String emoji;

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:postgresql:///sopra?cloudSqlInstance=sopra-fs26-group-21-server:europe-west6:sopra-fs26-db&socketFactory=com.google.cloud.sql.postgres.SocketFactory
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=spring-app
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+
+spring.h2.console.enabled=false


### PR DESCRIPTION
## Why
  Random logout bug (#67, #120) was caused by H2 in-memory loss on App Engine instance recycling. This migrates to Cloud SQL Postgres so data persists across redeploys
   + instance scaling.

  ## What changes
  - Add Postgres driver + `cloud-sql-jdbc-socket-factory` (build.gradle)                                                                            
  - New `application-prod.properties` — Spring connects via socket factory + IAM auth, `ddl-auto=update`
  - `app.yaml` — wire `beta_settings.cloud_sql_instances`, `SPRING_PROFILES_ACTIVE=prod`, password placeholder
  - CI: new step injects `secrets.DB_PASSWORD` into `app.yaml` before deploy
  - `Post.imageUrl` columnDefinition `CLOB` → `TEXT` (works on both H2 and Postgres)

  ## Tested locally (profile=prod against live Cloud SQL)
  - [x] Register + login persist across server restarts
  - [x] Events persist
  - [x] Chat messages persist
  - [x] H2 unit tests still pass (`./gradlew test`)

  ## Deploy prerequisites
  - Cloud SQL instance `sopra-fs26-db` running in `europe-west6`
  - GitHub Secret `DB_PASSWORD` set
  - Postgres user `spring-app` with `GRANT ALL PRIVILEGES ON DATABASE sopra` + `GRANT ALL ON SCHEMA public`