### PR TITLE
chore(app-engine): switch to scale-to-zero (min=0, max=2)

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,9 +5,9 @@ runtime: java17
 instance_class: F2
 
 automatic_scaling:
-  min_instances: 1
-  max_instances: 1
-  min_idle_instances: 1
+  min_instances: 0
+  max_instances: 2
+  min_idle_instances: 0
 
 beta_settings:
   cloud_sql_instances: sopra-fs26-group-21-server:europe-west6:sopra-fs26-db


### PR DESCRIPTION
Cloud SQL migration makes the previous max_instances=1 workaround obsolete: data now persists in Postgres across instance scaling, so we can let App Engine scale up under load and shut down when idle.

- min_instances 1 -> 0: scale-to-zero, no compute cost when idle (saves ~40-45 €/mo of F2 24/7)
- max_instances 1 -> 2: small headroom for traffic spikes, capped to avoid runaway cost
- min_idle_instances 1 -> 0: no idle reserved instance

Trade-off: first request after idle period triggers a ~10-15s cold start (JVM + Spring boot + Cloud SQL handshake). Acceptable post-demo for occasional use.