### PR TITLE
hotfix: cap HikariCP pool to 5 connections per instance

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,4 +5,11 @@ spring.datasource.password=${DB_PASSWORD}
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
+# Cloud SQL db-f1-micro has max_connections=25. With max 2 App Engine instances,
+# cap HikariCP at 5 connections per instance so worst case = 2 * 5 = 10 connections
+# (well under the 25 limit, leaves headroom for admin/monitoring connections).
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.connection-timeout=10000
+
 spring.h2.console.enabled=false


### PR DESCRIPTION
Cloud SQL Postgres db-f1-micro has max_connections=25. With 2 App Engine instances each opening a default HikariCP pool of 10, plus reserved slots and admin connections, the limit was hit under modest concurrent load — Postgres rejected new connections with "remaining connection slots are reserved" (FATAL ALERT in cloudsql logs), every Spring request returned 500 after ~110s waiting for a connection.

Cap pool at 5 per instance: worst case 2*5=10 connections, well under the 25 limit with headroom for monitoring/admin.

Also set connection-timeout=10s so users get a fast error instead of waiting 30s on connection exhaustion.

Fixes the post-deploy 500 storm observed on 2026-05-15 ~16:25-17:00.